### PR TITLE
add usePlaceholderId option

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -27,7 +27,7 @@ Builder.prototype._reset = function() {
 };
 
 Builder.prototype._getPlaceholder = function() {
-	return (this.options.namedValues ? 'p' : '') + (this._placeholderId++);
+	return (this.options.namedValues ? 'p' : '') + (this.options.usePlaceholderId ? (this._placeholderId++) : '');
 };
 
 Builder.prototype._wrapPlaceholder = function(name) {
@@ -64,7 +64,8 @@ Builder.prototype.configure = function(options) {
 		namedValues: true,
 		valuesPrefix: '$',
 		dialect: 'base',
-		wrappedIdentifiers: true
+		wrappedIdentifiers: true,
+		usePlaceholderId: true
 	});
 
 	this.setDialect(this.options.dialect);


### PR DESCRIPTION
mysqljs (others might too) requires query values to be escaped [via a question mark](https://github.com/mysqljs/mysql#performing-queries).
`usePlaceholderId` option is added In order to facilitate this behaviour
```javascript
let jsonSql = require('json-sql')({
  dialect: 'mysql',
  namedValues: false,
  valuesPrefix: '?',
  usePlaceholderId: false
});
```